### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 一种漂亮的UI控件，能更灵活的控制数字的增减。
 对应的iOS版 [SnappingStepper](https://github.com/yannickl/SnappingStepper)
 
-####使用说明
+#### 使用说明
 支持两种模式：setMode方法(Mode.AUTO是默认的在滑动条上有数值显示,Mode.CUSTOM是自定义文字配合setText函数)
 代码和xml预配置两种方式都可，更多自定义属性和样式参考demo。
 
-####使用gradle 依赖:
+#### 使用gradle 依赖:
 ```java
 compile 'com.bigkoo:snappingstepper:1.0.2'
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
